### PR TITLE
Adding rules corresponding to Wolox NodeJS established practices

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,42 @@
 # eslint-config-wolox-node
+
+Linter that extends [wolox-linter](https://github.com/Wolox/eslint-config-wolox/) adapted to the [practices](https://github.com/arinaldi118/documentacion/blob/master/standards.md) established for Wolox NodeJS proyects.  
+It uses a [plugin import](https://github.com/benmosher/eslint-plugin-import) to define some rules.
+
+## Contributing
+
+1. Fork it
+2. Create your feature branch (`git checkout -b my-new-feature`)
+3. Commit your changes (`git commit -am 'Add some feature'`)
+4. Push to the branch (`git push origin my-new-feature`)
+5. Create new Pull Request
+
+## About
+
+This project is maintained by [Wolox](https://github.com/wolox) and it was written by [Wolox](http://www.wolox.com.ar).
+
+![Wolox](https://raw.githubusercontent.com/Wolox/press-kit/master/logos/logo_banner.png)
+
+## License
+
+**express-wolox-logger** is available under the MIT [license](LICENSE.md).
+
+    Copyright (c) 2019 Wolox
+
+    Permission is hereby granted, free of charge, to any person obtaining a copy
+    of this software and associated documentation files (the "Software"), to deal
+    in the Software without restriction, including without limitation the rights
+    to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+    copies of the Software, and to permit persons to whom the Software is
+    furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in
+    all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+    THE SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 # eslint-config-wolox-node
 
-Linter that extends [wolox-linter](https://github.com/Wolox/eslint-config-wolox/) adapted to the [practices](https://github.com/arinaldi118/documentacion/blob/master/standards.md) established for Wolox NodeJS proyects.  
-It uses a [plugin import](https://github.com/benmosher/eslint-plugin-import) to define some rules.
+Linter that extends [wolox-linter](https://github.com/Wolox/eslint-config-wolox/) adapted to the [practices](https://github.com/arinaldi118/documentacion/blob/master/standards.md) established for Wolox NodeJS proyects.
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ This project is maintained by [Wolox](https://github.com/wolox) and it was writt
 
 ## License
 
-**express-wolox-logger** is available under the MIT [license](LICENSE.md).
+**eslint-config-wolox-node** is available under the MIT [license](LICENSE.md).
 
     Copyright (c) 2019 Wolox
 

--- a/index.js
+++ b/index.js
@@ -16,7 +16,6 @@ module.exports = {
     sourceType: "module"
   },
   extends: ["wolox"],
-  // https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/
   plugins: ["import"],
   globals: {
     __DEV__: true

--- a/index.js
+++ b/index.js
@@ -16,22 +16,29 @@ module.exports = {
     sourceType: "module"
   },
   extends: ["wolox"],
+  // https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/
   plugins: ["import"],
   globals: {
     __DEV__: true
   },
   rules: {
+    "arrow-body-style": ["error", "as-needed"],
     "arrow-parens": ["error", "as-needed"],
     "arrow-spacing": ["error", { before: true, after: true }],
     "camelcase": 0,
+    "curly": ["error", "multi"],
+    "global-require": "error",
+    "import/order": ["error", { groups: [["builtin", "external", "internal"]] }],
+    "import/named": "error",
+    "import/no-duplicates": "error",
+    "import/newline-after-import": "error",
+    "import/no-cycle": ["error", { maxDepth: Infinity }],
+    "import/no-useless-path-segments": "error",
     "max-len": ["error", { code: 100 }],
     "max-nested-callbacks": 0,
     "max-params": ["error", 4],
     "no-magic-numbers": 0,
-    "curly": ["error", "multi"],
-    "global-require": "error",
-    "one-var": ["error", "never"],
-    "import/order": ["error", { groups: [["builtin", "external", "internal"]] }],
+    "one-var": ["error", "never"]
   },
   settings: {
     "import/resolver": {

--- a/index.js
+++ b/index.js
@@ -16,7 +16,6 @@ module.exports = {
     sourceType: "module"
   },
   extends: ["wolox"],
-  plugins: ["import"],
   globals: {
     __DEV__: true
   },
@@ -27,13 +26,6 @@ module.exports = {
     "camelcase": 0,
     "curly": ["error", "multi"],
     "global-require": "error",
-    "import/order": ["error", { groups: [["builtin", "external", "internal"]] }],
-    "import/named": "error",
-    "import/no-duplicates": "error",
-    "import/newline-after-import": "error",
-    "import/no-cycle": ["error", { maxDepth: Infinity }],
-    "import/no-useless-path-segments": "error",
-    "max-len": ["error", { code: 100 }],
     "max-nested-callbacks": 0,
     "max-params": ["error", 4],
     "no-magic-numbers": 0,

--- a/index.js
+++ b/index.js
@@ -16,17 +16,22 @@ module.exports = {
     sourceType: "module"
   },
   extends: ["wolox"],
+  plugins: ["import"],
   globals: {
     __DEV__: true
   },
   rules: {
     "arrow-parens": ["error", "as-needed"],
-    "arrow-spacing": ['error', { before: true, after: true }],
+    "arrow-spacing": ["error", { before: true, after: true }],
     "camelcase": 0,
-    "max-len": ["error", { "code": 120 }],
+    "max-len": ["error", { code: 100 }],
     "max-nested-callbacks": 0,
     "max-params": ["error", 4],
     "no-magic-numbers": 0,
+    "curly": ["error", "multi"],
+    "global-require": "error",
+    "one-var": ["error", "never"],
+    "import/order": ["error", { groups: [["builtin", "external", "internal"]] }],
   },
   settings: {
     "import/resolver": {

--- a/index.js
+++ b/index.js
@@ -27,7 +27,6 @@ module.exports = {
     "curly": ["error", "multi"],
     "global-require": "error",
     "max-nested-callbacks": 0,
-    "max-params": ["error", 4],
     "no-magic-numbers": 0,
     "one-var": ["error", "never"]
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-wolox-node",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "description": "Wolox's ESLint configuration for NodeJS projects ",
   "main": "index.js",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "eslint-config-wolox": "^2.2.1",
     "prettier": "^1.15.3",
     "prettier-eslint": "^8.8.2",
-    "eslint-plugin-prettier": "^3.0.1"
+    "eslint-plugin-prettier": "^3.0.1",
+    "eslint-plugin-import": "^2.17.3"
   }
 }

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   "homepage": "https://github.com/Wolox/eslint-config-wolox-node#readme",
   "peerDependencies": {
     "eslint": "5.9.0",
-    "eslint-config-wolox": "^2.2.1",
+    "eslint-config-wolox": "^3.0.0",
     "prettier": "^1.15.3",
     "prettier-eslint": "^8.8.2",
     "eslint-plugin-prettier": "^3.0.1",


### PR DESCRIPTION
Wolox NodeJS established [practices](https://github.com/arinaldi118/documentacion/blob/master/standards.md).

Each rule matches an item of the practices document.
`curly` matches with 4.1
`global-require` matches with 7.2
`one-var` matches with 7.2
`import/order` matches with 7.2 -> I add this rule in [Wolox linter](https://github.com/Wolox/eslint-config-wolox/pull/12) so all JS techs can use it 
`arrow-body-style` matches with 7.4
