### PR TITLE
Fix no-extra-parens conflict with prettier

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## 3.0.0
+
+* Modified `no-extra-parens` rule to resolve conflict with prettier. 
+* Updated `ESLint` dependency version to `^6.4.0`
+
 ## 2.0.0
 
 * Changelog added.

--- a/index.js
+++ b/index.js
@@ -27,6 +27,7 @@ module.exports = {
     "curly": ["error", "multi-line"],
     "global-require": "error",
     "max-nested-callbacks": 0,
+    "no-extra-parens": ["error", "functions"],
     "no-magic-numbers": 0,
     "one-var": ["error", "never"]
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-wolox-node",
-  "version": "2.2.0",
+  "version": "3.0.0",
   "description": "Wolox's ESLint configuration for NodeJS projects ",
   "main": "index.js",
   "repository": {
@@ -19,11 +19,11 @@
   },
   "homepage": "https://github.com/Wolox/eslint-config-wolox-node#readme",
   "peerDependencies": {
-    "eslint": "5.9.0",
-    "eslint-config-wolox": "^3.0.2",
-    "prettier": "^1.15.3",
-    "prettier-eslint": "^8.8.2",
-    "eslint-plugin-prettier": "^3.0.1",
-    "eslint-plugin-import": "^2.17.3"
+    "eslint": "6.x",
+    "eslint-config-wolox": "4.x",
+    "prettier": "1.x",
+    "prettier-eslint": "9.x",
+    "eslint-plugin-prettier": "3.x",
+    "eslint-plugin-import": "2.x"
   }
 }


### PR DESCRIPTION
## Summary

[Change!] Modified `no-extra-parens` rule to solve a conflict with prettier
[Change!] ESLint dependencies updated

## Trello Card

[Change!] https://trello.com/c/NyWrgZfZ/126-fix-linter-no-extra-parens
